### PR TITLE
bugfix: select commands keep anchor position

### DIFF
--- a/src/commandFunctions.js
+++ b/src/commandFunctions.js
@@ -179,7 +179,7 @@ function _jumpForwardSelect (restrict, putCursorForward, query) {
 	const selections = editor.selections;
 
 	selections.forEach((selection, index) => {
-
+    const curAnchor = selection.anchor;
 		let curPos = selection.active;
 		let queryObject;
 
@@ -200,7 +200,7 @@ function _jumpForwardSelect (restrict, putCursorForward, query) {
 			}
 			else queryPos = editor.document.positionAt(queryObject.queryIndex + queryObject.cursorIndex);
 
-			selections[index] = new vscode.Selection(curPos, queryPos);
+			selections[index] = new vscode.Selection(curAnchor, queryPos);
 			editor.selections = selections;
 		}
 	});
@@ -269,7 +269,7 @@ function _jumpBackwardSelect(restrict, putCursorBackward, query) {
 	const selections = editor.selections;
 
 	selections.forEach((selection, index) => {
-
+    const curAnchor = selection.anchor;
 		let curPos = selection.active;
 		let queryObject;
 
@@ -293,7 +293,7 @@ function _jumpBackwardSelect(restrict, putCursorBackward, query) {
 				else queryPos = editor.document.positionAt(queryObject.queryIndex);
 			}
 
-			selections[index] = new vscode.Selection(curPos, queryPos);
+			selections[index] = new vscode.Selection(curAnchor, queryPos);
 			editor.selections = selections;
 		}
 	});


### PR DESCRIPTION
Hey ArtudoDent, I know you haven't worked on this repo, so let me know if you are no longer interested in maintaining it and I will just use my fork! 

Otherwise, this bugfix changes the commands to keep the original anchor position so that jump-and-select can be used to extend selections.

Both `jump-and-select.jump{Forward,Backward}Select` and `jump-and-select.jump{Forward,Backward}SelectMultiMode` commands set selection anchors as the current cursor position (selection.active position). This results in a bug where a current selection is overridden by these commands, which was particularly obvious with multimode creating a new selection for every jump made. 

## Before changes

https://github.com/ArturoDent/jump-and-select/assets/44491043/b0f1fd76-8a90-49ea-8669-ce0823ab0034

## After Changes

https://github.com/ArturoDent/jump-and-select/assets/44491043/d9ae85a6-78f3-4b7f-824f-9d126b9d8296





